### PR TITLE
Support for team viewers

### DIFF
--- a/cacher_create_snippet.py
+++ b/cacher_create_snippet.py
@@ -12,7 +12,7 @@ def library_labels(library_guid):
 
     libraries = list()
     libraries.append(store.get("personal_library"))
-    libraries += list(map(lambda team: team["library"], store.get("teams")))
+    libraries += list(map(lambda team: team["library"], store.get("teams_editable")))
 
     library = list(filter(lambda lib: lib["guid"] == library_guid, libraries))[0]
     return library["labels"]
@@ -38,7 +38,7 @@ class SnippetLibraryInputHandler(sublime_plugin.ListInputHandler):
         )
 
         # Teams
-        for team in store.get("teams"):
+        for team in store.get("teams_editable"):
             items.append(
                 (team["name"], team["library"]["guid"])
             )

--- a/cacher_insert_snippet.py
+++ b/cacher_insert_snippet.py
@@ -28,6 +28,8 @@ class InsertSnippetInputHandler(sublime_plugin.ListInputHandler):
                         description = "({0}) {1}".format(label, description)
 
                 title = "{0} / {1} - {2}".format(snippet["title"], file["filename"], description)
+                title = title[:150]
+
                 list_snippets.append(
                     (title, file["content"])
                 )

--- a/lib/snippets.py
+++ b/lib/snippets.py
@@ -123,5 +123,8 @@ def snippet_labels(labels, snippet):
 
 def set_teams(data):
     util.store().set("teams", data["teams"])
-    teams_editable = []
-
+    teams_editable = list(filter(
+        lambda team: team["userRole"] == "owner" or team["userRole"] == "manager" or team["userRole"] == "member",
+        data["teams"]
+    ))
+    util.store().set("teams_editable", teams_editable)

--- a/lib/snippets.py
+++ b/lib/snippets.py
@@ -35,6 +35,8 @@ def list_snippet(snippet):
             description = "({0}) {1}".format(label, description)
 
     title = "{0} - {1}".format(snippet["title"], description)
+    title = title[:150]
+
     return title, snippet["guid"]
 
 
@@ -121,3 +123,5 @@ def snippet_labels(labels, snippet):
 
 def set_teams(data):
     util.store().set("teams", data["teams"])
+    teams_editable = []
+


### PR DESCRIPTION
- Prohibit users with the team viewer role from creating snippets in teams.
- Trim long titles for list picker handler.